### PR TITLE
enable hpu profile

### DIFF
--- a/fastdeploy/demo/run.sh
+++ b/fastdeploy/demo/run.sh
@@ -7,5 +7,9 @@ export PADDLE_DISTRI_BACKEND=xccl
 export PADDLE_XCCL_BACKEND=intel_hpu
 # export FLAGS_selected_intel_hpus=0,1,2,3,4,5,6,7
 export FLAGS_selected_intel_hpus=0
-rm -rf log
+# export HABANA_PROFILE=1
+# export HABANA_LOGS=hpu_logs
+# export LOG_LEVEL_ALL=0
+
+rm -rf log hpu_logs
 FD_ATTENTION_BACKEND=BLOCK_ATTN python offline_demo.py

--- a/fastdeploy/worker/hpu_model_runner.py
+++ b/fastdeploy/worker/hpu_model_runner.py
@@ -303,6 +303,16 @@ class HPUModelRunner(ModelRunnerBase):
             self.local_rank +
             int(self.parallel_config.engine_worker_queue_port))
 
+        if int(os.environ.get("HABANA_PROFILE", 0)) == 1:
+            step_start = int(os.environ.get("PROFILE_START", 0))
+            step_end = int(os.environ.get("PROFILE_END", 4))
+            import paddle.profiler as profiler
+            self.prof = profiler.Profiler(
+                targets=[profiler.ProfilerTarget.CPU, profiler.ProfilerTarget.CUSTOM_DEVICE],
+                scheduler=(step_start, step_end),
+                on_trace_ready = profiler.export_chrome_tracing('./profile'))
+            self.prof.start()
+
     def prefill_finished(self):
         """
         check whether prefill stage finished
@@ -1215,6 +1225,9 @@ class HPUModelRunner(ModelRunnerBase):
 
         self._update_chunked_prefill(model_forward_batch)
         self._add_cache(model_forward_batch)
+
+        if int(os.environ.get("HABANA_PROFILE", 0)) == 1:
+            self.prof.step()
         return None
 
     def _add_cache(self, model_forward_batch) -> None:


### PR DESCRIPTION
steps to use hpu profile:
1.  enable hl profile API mode by cmd below. (Just need do once)
   >> hl-prof-config -i
2. enable hpu profile by setting env:
   HABANA_PROFILE=1
   PROFILE_START=xxx     // if no set, it is 0 by default
   PROFILE_END=xxx       // if no set, it is 4 by default.

   START/END means profile step #
    user can select  step start/end, and make sure end > start.