### PR TITLE
Add a flag to switch cpu/gpu top_p_sampling

### DIFF
--- a/fastdeploy/model_executor/layers/sample/sampler.py
+++ b/fastdeploy/model_executor/layers/sample/sampler.py
@@ -255,8 +255,18 @@ class Sampler(nn.Layer):
 
         probs = F.softmax(logits)
 
-        _, next_tokens = paddle.tensor.top_p_sampling(probs,
-                                                      sampling_metadata.top_p)
+        use_cpu = False 
+        place = probs.place
+
+        if use_cpu and not place.is_cpu_place():
+            probs_cpu = probs.cpu()
+            top_p_cpu = sampling_metadata.top_p.cpu()
+            _, next_tokens = paddle.tensor.top_p_sampling(probs_cpu,
+                                                          top_p_cpu)
+            next_tokens = next_tokens.to(place)
+        else:
+            _, next_tokens = paddle.tensor.top_p_sampling(probs,
+                                                          sampling_metadata.top_p)
 
         if next_tokens.shape[0] != max_batch:
             dim = next_tokens.shape[-1]


### PR DESCRIPTION
Add a flag "use_cpu" in forward_intel_hpu to support manually switching between hpu top_p_sampling and cpu top_p_sampling
- By default it is False which means to use hpu path

Performance test result.

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/jli94/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/jli94/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{text-align:center;
	border:.5pt solid windowtext;}
-->
</head>

<body link="#467886" vlink="#96607D">


Batch Size | Token   throughput
-- | --
1 | 0.955281207
8 | 1.013510275
64 | 0.941505991
128 | 1.169941133



</body>

</html>
