### PR TITLE
Fix the accuracy issue of gsm8k

### DIFF
--- a/fastdeploy/model_executor/layers/sample/sampler.py
+++ b/fastdeploy/model_executor/layers/sample/sampler.py
@@ -416,7 +416,9 @@ class Sampler(nn.Layer):
 
         if next_tokens.shape[0] != max_batch:
             dim = next_tokens.shape[-1]
-            tmp_tokens = paddle.full((max_batch, dim), -1, dtype=next_tokens.dtype)
+            tmp_tokens = paddle.full((max_batch, dim),
+                                     -1 if local_rank is 0 else 0,
+                                     dtype=next_tokens.dtype)
             tmp_tokens = paddle.scatter(tmp_tokens, batch_ids, next_tokens[: batch_ids.shape[0], :])
             return tmp_tokens
 


### PR DESCRIPTION
The output of distributed sampler will be scattered to an array whose initial values are -1. After all_reduce, these -1 will be added up and causing accuracy issues.
To fix it, only set rank0's initial value to -1 and set other ranks' initial value to 0.