### PR TITLE
Support Qwen3 MoE

### DIFF
--- a/fastdeploy/model_executor/layers/backends/intel_hpu/moe/fused_moe_hpu_backend.py
+++ b/fastdeploy/model_executor/layers/backends/intel_hpu/moe/fused_moe_hpu_backend.py
@@ -14,52 +14,34 @@
 # limitations under the License.
 """
 
+import os
 import paddle
 from paddle import nn
 
 from fastdeploy.distributed.communication import tensor_model_parallel_all_reduce_custom
-from fastdeploy.model_executor.layers.moe.fused_moe_backend_base import MoEMethodBase
+from fastdeploy.model_executor.layers.moe.fused_moe_backend_base import MoEMethodBase, UnquantizedFusedMoEMethod
 from fastdeploy.model_executor.layers.utils import get_tensor
 
 
-class HpuMoEMethod(MoEMethodBase):
+class HpuMoEMethod(UnquantizedFusedMoEMethod):
     """
     Use Cutlass Group Gemm to compute Fused MoE.
     This method is the oldest way to compute MoE in Paddle.
     """
 
-    def create_weights(self, layer: nn.Layer, **extra_weight_attrs):
-        # TODO: split create_parameter from process_loaded_weights
-        return NotImplemented
-
     def process_loaded_weights(self, layer: nn.Layer, state_dict):
         """
         Paddle HPU load weight process.
         """
-        # bf16
-        up_gate_proj_weights, down_proj_weights, _, _ = layer.extract_moe_ffn_weights(state_dict)
-
-        up_gate_proj_expert_weight_key = layer.weight_key_map.get("up_gate_proj_expert_weight_key", None)
-        down_proj_expert_weight_key = layer.weight_key_map.get("down_proj_expert_weight_key", None)
-        # for measurement mode
-        self.up_gate_proj_act_scale_key = up_gate_proj_expert_weight_key.replace("{}.", "").replace(
-            "weight", "activation_scale"
+        up_gate_proj_weights, down_proj_weights, logical_expert_ids, ep_rank_to_expert_id_list = (
+            layer.extract_moe_ffn_weights(state_dict)
         )
-        self.down_proj_expert_act_scale_key = down_proj_expert_weight_key.replace("weight", "activation_scale")
+        stacked_up_gate_proj_weights = paddle.stack(up_gate_proj_weights, axis=0)
+        stacked_down_proj_weights = paddle.stack(down_proj_weights, axis=0)
 
-        for idx, weights_tensor in enumerate([up_gate_proj_weights, down_proj_weights]):
-            weights_list = []
-            for i in range(layer.num_local_experts):
-                weight_tensor = weights_tensor[i]
-                weight = layer.create_parameter(
-                    shape=weight_tensor.shape,
-                    dtype=weight_tensor.dtype,
-                    default_initializer=paddle.nn.initializer.Constant(0),
-                )
-                weight.set_value(weight_tensor)
-                weights_list.append(weight)
-            weights_name = self.added_weight_attrs[idx]
-            setattr(layer, weights_name, weights_list)
+        layer.up_gate_proj_weight.set_value(stacked_up_gate_proj_weights)
+        layer.down_proj_weight.set_value(stacked_down_proj_weights)
+
 
     def apply_ep_prefill(
         self,
@@ -96,7 +78,7 @@ class HpuMoEMethod(MoEMethodBase):
             raise NotImplementedError
 
         # norm_topk_prob = False if layer.topk_method == "noaux_tc" else True
-        chunk_size = 64
+        chunk_size = int(os.environ.get("HPU_CHUNK_SIZE", 64))
         measurement_mode = getattr(layer, "measurement_mode", False)
         if measurement_mode:
             from fastdeploy.model_executor.ops.intel_hpu import fused_gate_moe_ref

--- a/fastdeploy/model_executor/layers/moe/fused_moe_backend_base.py
+++ b/fastdeploy/model_executor/layers/moe/fused_moe_backend_base.py
@@ -174,7 +174,7 @@ class MoEMethodBase(QuantMethodBase):
 class UnquantizedFusedMoEMethod(MoEMethodBase):
     def create_weights(self, layer: nn.Layer, **extra_weight_attrs):
 
-        if current_platform.is_cuda():
+        if current_platform.is_cuda() or current_platform.is_intel_hpu():
             self.up_gate_proj_weight_shape = [layer.num_experts, layer.hidden_size, layer.moe_intermediate_size * 2]
             self.down_proj_weight_shape = [layer.num_experts, layer.moe_intermediate_size, layer.hidden_size]
             extra_weight_attrs = {**extra_weight_attrs, "SHARD_ID_TO_SHARDED_DIM": {"gate": 1, "down": 0, "up": 1}}

--- a/fastdeploy/worker/hpu_model_runner.py
+++ b/fastdeploy/worker/hpu_model_runner.py
@@ -304,8 +304,26 @@ from fastdeploy.model_executor.layers.moe.moe import FusedMoE
 from fastdeploy.model_executor.models.ernie4_5_moe import (
     Ernie4_5_Attention,
     Ernie4_5_MLP,
+    Ernie4_5_DecoderLayer,
 )
 from fastdeploy.model_executor.models.qwen2 import Qwen2Attention, Qwen2MLP
+from fastdeploy.model_executor.models.qwen3 import Qwen3Attention
+from fastdeploy.model_executor.models.qwen3moe import Qwen3DecoderLayer
+
+
+def process_moe_weights_after_loading(layer) -> None:
+    if hasattr(layer.mlp, "experts"):
+        experts = layer.mlp.experts
+        num_experts = experts.num_experts
+
+        up_gate_proj_weight = [experts.up_gate_proj_weight[i] for i in range(num_experts)]
+        down_proj_weight = [experts.down_proj_weight[i] for i in range(num_experts)]
+
+        del layer.mlp.experts.up_gate_proj_weight
+        del layer.mlp.experts.down_proj_weight
+
+        layer.mlp.experts.up_gate_proj_weight = up_gate_proj_weight
+        layer.mlp.experts.down_proj_weight = down_proj_weight
 
 
 def convert_model(model, measurement_mode=False):
@@ -320,11 +338,17 @@ def convert_model(model, measurement_mode=False):
                 module.forward = types.MethodType(fused_self_atten_forward, module)
             if isinstance(module, Qwen2Attention):
                 module.forward = types.MethodType(fused_self_atten_forward, module)
+            if isinstance(module, Qwen3Attention):
+                module.forward = types.MethodType(fused_self_atten_forward, module)
             if isinstance(module, Ernie4_5_MLP):
                 module.measurement_mode = measurement_mode
                 module.forward = types.MethodType(fused_mlp_forward, module)
             if isinstance(module, Qwen2MLP):
                 module.forward = types.MethodType(fused_mlp_forward, module)
+            if isinstance(module, Ernie4_5_DecoderLayer):
+                process_moe_weights_after_loading(module)
+            if isinstance(module, Qwen3DecoderLayer):
+                process_moe_weights_after_loading(module)
             convert_model(module, measurement_mode)
         else:
             if isinstance(module, Attention):


### PR DESCRIPTION
In this commit:
- HpuMoEMethod::process_loaded_weights  aligns with cutlass_backend
- Deferred the 3D tensor of up_gate_proj_weights/down_proj_weights till the whole MoE weights are loaded
- chunk_size changed from 64 to 0 to fix the OOM during fused_gate_moe compilation 

p.s. **is_paddle_support_v1_loader** is only contained in the develop branch. develop_hpu doen't have this check.