### PR TITLE
MoE weights and scales from list to tensor

### DIFF
--- a/fastdeploy/model_executor/layers/backends/intel_hpu/moe/fused_moe_hpu_backend.py
+++ b/fastdeploy/model_executor/layers/backends/intel_hpu/moe/fused_moe_hpu_backend.py
@@ -330,7 +330,7 @@ class HpuTensorWiseFP8MoEMethod(HpuMoEMethod):
 
         # norm_topk_prob = False if layer.topk_method == "noaux_tc" else True
 
-        chunk_size = 64
+        chunk_size = int(os.environ.get("HPU_CHUNK_SIZE", 64))
         from fastdeploy.model_executor.ops.intel_hpu import fused_gate_moe_fp8
 
         fused_moe_out = fused_gate_moe_fp8(

--- a/fastdeploy/model_executor/layers/backends/intel_hpu/moe/fused_moe_hpu_backend.py
+++ b/fastdeploy/model_executor/layers/backends/intel_hpu/moe/fused_moe_hpu_backend.py
@@ -14,12 +14,13 @@
 # limitations under the License.
 """
 
-import os
 import paddle
 from paddle import nn
 
 from fastdeploy.distributed.communication import tensor_model_parallel_all_reduce_custom
-from fastdeploy.model_executor.layers.moe.fused_moe_backend_base import MoEMethodBase, UnquantizedFusedMoEMethod
+from fastdeploy.model_executor.layers.moe.fused_moe_backend_base import (
+    UnquantizedFusedMoEMethod,
+)
 from fastdeploy.model_executor.layers.utils import get_tensor
 
 
@@ -33,15 +34,21 @@ class HpuMoEMethod(UnquantizedFusedMoEMethod):
         """
         Paddle HPU load weight process.
         """
-        up_gate_proj_weights, down_proj_weights, logical_expert_ids, ep_rank_to_expert_id_list = (
-            layer.extract_moe_ffn_weights(state_dict)
-        )
+        # bf16
+        up_gate_proj_weights, down_proj_weights, _, _ = layer.extract_moe_ffn_weights(state_dict)
+
         stacked_up_gate_proj_weights = paddle.stack(up_gate_proj_weights, axis=0)
         stacked_down_proj_weights = paddle.stack(down_proj_weights, axis=0)
-
         layer.up_gate_proj_weight.set_value(stacked_up_gate_proj_weights)
         layer.down_proj_weight.set_value(stacked_down_proj_weights)
 
+        # for measurement mode
+        up_gate_proj_expert_weight_key = layer.weight_key_map.get("up_gate_proj_expert_weight_key", None)
+        down_proj_expert_weight_key = layer.weight_key_map.get("down_proj_expert_weight_key", None)
+        self.up_gate_proj_act_scale_key = up_gate_proj_expert_weight_key.replace("{}.", "").replace(
+            "weight", "activation_scale"
+        )
+        self.down_proj_expert_act_scale_key = down_proj_expert_weight_key.replace("weight", "activation_scale")
 
     def apply_ep_prefill(
         self,
@@ -78,7 +85,7 @@ class HpuMoEMethod(UnquantizedFusedMoEMethod):
             raise NotImplementedError
 
         # norm_topk_prob = False if layer.topk_method == "noaux_tc" else True
-        chunk_size = int(os.environ.get("HPU_CHUNK_SIZE", 64))
+        chunk_size = 64
         measurement_mode = getattr(layer, "measurement_mode", False)
         if measurement_mode:
             from fastdeploy.model_executor.ops.intel_hpu import fused_gate_moe_ref
@@ -133,9 +140,6 @@ class HpuTensorWiseFP8MoEMethod(HpuMoEMethod):
         """
         Paddle HPU process prequanted weights.
         """
-        up_gate_proj_weight, down_proj_weight, logical_expert_ids, _ = layer.extract_moe_ffn_weights(state_dict)
-        up_gate_proj_weight = [t.view(paddle.float8_e4m3fn) for t in up_gate_proj_weight]
-        down_proj_weight = [t.view(paddle.float8_e4m3fn) for t in down_proj_weight]
 
         def _extract_scale_tensor(key_template, logical_expert_ids):
             result = []
@@ -162,6 +166,10 @@ class HpuTensorWiseFP8MoEMethod(HpuMoEMethod):
                 reciprocal = 1.0 / scale_tensor
                 return reciprocal.cast(paddle.get_default_dtype())
 
+        up_gate_proj_weight, down_proj_weight, logical_expert_ids, _ = layer.extract_moe_ffn_weights(state_dict)
+        up_gate_proj_weights = [t.view(paddle.float8_e4m3fn) for t in up_gate_proj_weight]
+        down_proj_weights = [t.view(paddle.float8_e4m3fn) for t in down_proj_weight]
+
         weight_key_map = layer.weight_key_map
 
         up_gate_proj_expert_weight_scale_key = weight_key_map.get("up_gate_proj_expert_weight_scale_key", None)
@@ -174,20 +182,87 @@ class HpuTensorWiseFP8MoEMethod(HpuMoEMethod):
         up_gate_proj_in_scale = _extract_descale_tensor(up_gate_proj_expert_in_scale_key, logical_expert_ids)
         down_proj_in_scale = _extract_scale_tensor(down_proj_expert_in_scale_key, logical_expert_ids)
 
+        up_gate_proj_weight = paddle.stack(up_gate_proj_weights, axis=0)
+        down_proj_weight = paddle.stack(down_proj_weights, axis=0)
+        up_gate_proj_weight_scale = paddle.stack(up_gate_proj_weight_scale, axis=0)
+        down_proj_weight_scale = paddle.stack(down_proj_weight_scale, axis=0)
+
         name_tensor_map = {
             "up_gate_proj_weight": up_gate_proj_weight,
             "down_proj_weight": down_proj_weight,
             "up_gate_proj_weight_scale": up_gate_proj_weight_scale,
             "down_proj_weight_scale": down_proj_weight_scale,
             "up_gate_proj_in_scale": up_gate_proj_in_scale,
-            "down_proj_in_scale": down_proj_in_scale,
         }
-        for name, tensor_list in name_tensor_map.items():
-            setattr(layer, name, tensor_list)
+        for name, tensor in name_tensor_map.items():
+            getattr(layer, name).set_value(tensor)
+        setattr(layer, "down_proj_in_scale", down_proj_in_scale)
 
     def create_weights(self, layer: nn.Layer, **extra_weight_attrs):
-        # TODO: split create_parameter from process_loaded_weights
-        return NotImplemented
+        """
+        Paddle HPU create weight process.
+        """
+        self.weight_dtype = "float8_e4m3fn"
+        self.up_gate_proj_weight_shape = [
+            layer.num_local_experts,
+            layer.hidden_size,
+            layer.moe_intermediate_size * 2,
+        ]
+        self.down_proj_weight_shape = [
+            layer.num_local_experts,
+            layer.moe_intermediate_size,
+            layer.hidden_size,
+        ]
+        setattr(
+            layer,
+            self.added_weight_attrs[0],
+            layer.create_parameter(
+                shape=self.up_gate_proj_weight_shape,
+                dtype=self.weight_dtype,
+                default_initializer=paddle.nn.initializer.Constant(0),
+            ),
+        )
+        setattr(
+            layer,
+            self.added_weight_attrs[1],
+            layer.create_parameter(
+                shape=self.down_proj_weight_shape,
+                dtype=self.weight_dtype,
+                default_initializer=paddle.nn.initializer.Constant(0),
+            ),
+        )
+
+        self.default_dtype = layer._helper.get_default_dtype()
+        # in_scales
+        setattr(
+            layer,
+            "up_gate_proj_in_scale",
+            layer.create_parameter(
+                shape=[1],
+                dtype=self.default_dtype,
+                default_initializer=paddle.nn.initializer.Constant(0),
+            ),
+        )
+
+        # weight_scales
+        setattr(
+            layer,
+            "up_gate_proj_weight_scale",
+            layer.create_parameter(
+                shape=[layer.num_local_experts, layer.moe_intermediate_size * 2],
+                dtype=self.default_dtype,
+                default_initializer=paddle.nn.initializer.Constant(0),
+            ),
+        )
+        setattr(
+            layer,
+            "down_proj_weight_scale",
+            layer.create_parameter(
+                shape=[layer.num_local_experts, layer.hidden_size],
+                dtype=self.default_dtype,
+                default_initializer=paddle.nn.initializer.Constant(0),
+            ),
+        )
 
     def process_loaded_weights(self, layer: nn.Layer, state_dict):
         """

--- a/fastdeploy/model_executor/layers/backends/intel_hpu/moe/fused_moe_hpu_backend.py
+++ b/fastdeploy/model_executor/layers/backends/intel_hpu/moe/fused_moe_hpu_backend.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """
 
+import os
+
 import paddle
 from paddle import nn
 
@@ -85,7 +87,7 @@ class HpuMoEMethod(UnquantizedFusedMoEMethod):
             raise NotImplementedError
 
         # norm_topk_prob = False if layer.topk_method == "noaux_tc" else True
-        chunk_size = 64
+        chunk_size = int(os.environ.get("HPU_CHUNK_SIZE", 64))
         measurement_mode = getattr(layer, "measurement_mode", False)
         if measurement_mode:
             from fastdeploy.model_executor.ops.intel_hpu import fused_gate_moe_ref

--- a/fastdeploy/model_executor/layers/moe/fused_moe_backend_base.py
+++ b/fastdeploy/model_executor/layers/moe/fused_moe_backend_base.py
@@ -174,9 +174,17 @@ class MoEMethodBase(QuantMethodBase):
 class UnquantizedFusedMoEMethod(MoEMethodBase):
     def create_weights(self, layer: nn.Layer, **extra_weight_attrs):
 
-        if current_platform.is_cuda() or current_platform.is_intel_hpu():
+        if current_platform.is_cuda():
             self.up_gate_proj_weight_shape = [layer.num_experts, layer.hidden_size, layer.moe_intermediate_size * 2]
             self.down_proj_weight_shape = [layer.num_experts, layer.moe_intermediate_size, layer.hidden_size]
+            extra_weight_attrs = {**extra_weight_attrs, "SHARD_ID_TO_SHARDED_DIM": {"gate": 1, "down": 0, "up": 1}}
+        elif current_platform.is_intel_hpu():
+            self.up_gate_proj_weight_shape = [
+                layer.num_local_experts,
+                layer.hidden_size,
+                layer.moe_intermediate_size * 2,
+            ]
+            self.down_proj_weight_shape = [layer.num_local_experts, layer.moe_intermediate_size, layer.hidden_size]
             extra_weight_attrs = {**extra_weight_attrs, "SHARD_ID_TO_SHARDED_DIM": {"gate": 1, "down": 0, "up": 1}}
         else:
             self.up_gate_proj_weight_shape = [layer.num_experts, layer.moe_intermediate_size * 2, layer.hidden_size]

--- a/fastdeploy/model_executor/load_weight_utils.py
+++ b/fastdeploy/model_executor/load_weight_utils.py
@@ -74,7 +74,8 @@ def reload_ep_checkpoint(model_path: str, fd_config: FDConfig, state_dict: dict,
             down_proj_scale_key = f"ernie.layers.{i}.mlp.experts.{j}.down_proj.weight_scale"
 
             down_proj_in_scale_key = f"ernie.layers.{i}.mlp.experts.{j}.down_proj.activation_scale"
-            up_gate_proj_in_scale_key = f"ernie.layers.{i}.mlp.experts.{j}.up_gate_proj.activation_scale"
+            # single up_gate_proj.activation_scale for all mlp.experts
+            up_gate_proj_in_scale_key = f"ernie.layers.{i}.mlp.experts.up_gate_proj.activation_scale"
 
             num_local_ffn_keys.append(up_gate_proj_key)
             num_local_ffn_keys.append(down_proj_key)

--- a/fastdeploy/model_executor/load_weight_utils.py
+++ b/fastdeploy/model_executor/load_weight_utils.py
@@ -74,8 +74,7 @@ def reload_ep_checkpoint(model_path: str, fd_config: FDConfig, state_dict: dict,
             down_proj_scale_key = f"ernie.layers.{i}.mlp.experts.{j}.down_proj.weight_scale"
 
             down_proj_in_scale_key = f"ernie.layers.{i}.mlp.experts.{j}.down_proj.activation_scale"
-            # single up_gate_proj.activation_scale for all mlp.experts
-            up_gate_proj_in_scale_key = f"ernie.layers.{i}.mlp.experts.up_gate_proj.activation_scale"
+            up_gate_proj_in_scale_key = f"ernie.layers.{i}.mlp.experts.{j}.up_gate_proj.activation_scale"
 
             num_local_ffn_keys.append(up_gate_proj_key)
             num_local_ffn_keys.append(down_proj_key)

--- a/fastdeploy/model_executor/models/ernie4_5_moe.py
+++ b/fastdeploy/model_executor/models/ernie4_5_moe.py
@@ -776,6 +776,10 @@ class Ernie4_5_MoePretrainedModel(PretrainedModel):
             tsm.PairFused,
         ),
         WeightMeta(
+            f".layers.{{{layerid.MOE_LAYER_ID}}}.mlp.experts.{{{layerid.EXPERT_ID}}}.up_gate_proj.weight_scale",
+            True,
+        ),
+        WeightMeta(
             f".layers.{{{layerid.MOE_LAYER_ID}}}.mlp.experts.{{{layerid.EXPERT_ID}}}.down_proj.quant_weight",
             False,
         ),

--- a/fastdeploy/worker/hpu_model_runner.py
+++ b/fastdeploy/worker/hpu_model_runner.py
@@ -311,26 +311,9 @@ from fastdeploy.model_executor.layers.moe.moe import FusedMoE
 from fastdeploy.model_executor.models.ernie4_5_moe import (
     Ernie4_5_Attention,
     Ernie4_5_MLP,
-    Ernie4_5_DecoderLayer,
 )
 from fastdeploy.model_executor.models.qwen2 import Qwen2Attention, Qwen2MLP
 from fastdeploy.model_executor.models.qwen3 import Qwen3Attention
-from fastdeploy.model_executor.models.qwen3moe import Qwen3DecoderLayer
-
-
-def process_moe_weights_after_loading(layer) -> None:
-    if hasattr(layer.mlp, "experts"):
-        experts = layer.mlp.experts
-        num_experts = experts.num_experts
-
-        up_gate_proj_weight = [experts.up_gate_proj_weight[i] for i in range(num_experts)]
-        down_proj_weight = [experts.down_proj_weight[i] for i in range(num_experts)]
-
-        del layer.mlp.experts.up_gate_proj_weight
-        del layer.mlp.experts.down_proj_weight
-
-        layer.mlp.experts.up_gate_proj_weight = up_gate_proj_weight
-        layer.mlp.experts.down_proj_weight = down_proj_weight
 
 
 def convert_model(model, measurement_mode=False):
@@ -352,10 +335,6 @@ def convert_model(model, measurement_mode=False):
                 module.forward = types.MethodType(fused_mlp_forward, module)
             if isinstance(module, Qwen2MLP):
                 module.forward = types.MethodType(fused_mlp_forward, module)
-            if isinstance(module, Ernie4_5_DecoderLayer):
-                process_moe_weights_after_loading(module)
-            if isinstance(module, Qwen3DecoderLayer):
-                process_moe_weights_after_loading(module)
             convert_model(module, measurement_mode)
         else:
             if isinstance(module, Attention):


### PR DESCRIPTION
Enable channel wise accordingly

# bf16 list to tensor:
- up_gate_proj_weights
- down_proj_weights

# fp8 list to tensor:
- up_gate_proj_weights
- down_proj_weights
- up_gate_proj_weight_scale
- down_proj_weight_scale

# fp8 keep list:
- down_proj_in_scale

# fp8 single tensor:
- up_gate_proj_in_scale

# tested cases:
- bf16 / fp8 1 card
- bf16 / fp8 2 cards with enTpEp = True / False
- bf16 1 card / 2 card with measurement